### PR TITLE
chore: Upgrade default Moondream to latest (2025-01-09)

### DIFF
--- a/build/requirements-moondream.txt
+++ b/build/requirements-moondream.txt
@@ -1,5 +1,7 @@
 transformers
 einops
+pyvips-binary==8.16.0
+pyvips==2.2.3
 pillow
 torch
 torchvision

--- a/describer/moondream.py
+++ b/describer/moondream.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import datetime, time
 
 MODEL_ID = 'vikhyatk/moondream2'
-MODEL_VERSION = '2024-07-23'
+MODEL_VERSION = '2025-01-09'
 
 
 class Moondream(ImageDescriber):


### PR DESCRIPTION
Fix for #20 
Note that this version of Moondream has a new requirement: `pyvips`, which is an image libary.

It is hard for me to test this locally as I'm on a Mac. It works on Linux VM, but please check it works for you also before merging.